### PR TITLE
perf(resolver): replace Math.max with custom method

### DIFF
--- a/src/schema/resolver.ts
+++ b/src/schema/resolver.ts
@@ -1,9 +1,11 @@
+import {getMaxOfArray} from "../utils"
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function resolveSchema(schema: any, data: any): any {
   if (Array.isArray(data)) {
     // finds the biggest element in the data so we can build our schema from that
     const sizes = data.map(entry => Object.values(entry).length)
-    const max = Math.max(...sizes)
+    const max = getMaxOfArray(sizes)
     const idx = sizes.indexOf(max)
 
     return resolveSchema(schema, {...data[idx]})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,3 +63,7 @@ export function sanitizeString(str: string): string {
   str = str.replace(/[^a-z0-9áéíóúñü \.,_-]/gim, "")
   return str.trim()
 }
+
+export function getMaxOfArray(array: any[]): number {
+  return array.reduce((max, v) => (max >= v ? max : v), -Infinity)
+}


### PR DESCRIPTION
This PR fixes the error caused by `Math.max` when working with a lot of data