### PR TITLE
feat: add strict mode on schema and insertion data

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "license": "MIT",
   "dependencies": {
     "@lyrasearch/lyra": "^0.3.1",
-    "@mateonunez/lyra-schema-resolver": "^0.1.2",
+    "@mateonunez/lyra-schema-resolver": "^0.1.3",
     "undici": "^5.14.0"
   },
   "devDependencies": {

--- a/src/runtimes/client/index.ts
+++ b/src/runtimes/client/index.ts
@@ -10,7 +10,7 @@ export async function impact<T extends PropertiesSchema>(url: string, options?: 
   const data = (await fetcher(url, {...fetcherOptions})) as unknown as T
   const lyra = createLyra(data, options?.lyra)
 
-  insertLyraData(lyra, data)
+  insertLyraData(lyra, data, {strict: options?.strict || false})
 
   return lyra as unknown as Lyra<T>
 }

--- a/src/runtimes/server/index.ts
+++ b/src/runtimes/server/index.ts
@@ -8,9 +8,9 @@ export async function impact<T extends PropertiesSchema>(url: string, options?: 
   const fetcherOptions = getFetcherOptions("rest", options?.property, options?.fetch)
 
   const data = (await fetcher(url, {...fetcherOptions})) as unknown as T
-  const lyra = createLyra(data, options?.lyra)
+  const lyra = createLyra(data, {...options?.lyra, strict: options?.strict || false})
 
-  insertLyraData(lyra, data)
+  insertLyraData(lyra, data, {strict: options?.strict || false})
 
   return lyra as unknown as Lyra<T>
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export type ImpactOptions = {
   lyra?: Omit<LyraConfiguration<any>, "schema">
   fetch?: FetcherOptions<RestOptions | GraphqlOptions | FilesystemOptions>
   property?: string
+  strict?: boolean
 }
 
 export type RestOptions = RequestInit


### PR DESCRIPTION
This PR closes #74 and #75 by implementing the `strict` mode in the schema resolution and data insertion.